### PR TITLE
make new participant input field use more available width, fix #73

### DIFF
--- a/js/app/css/style.css
+++ b/js/app/css/style.css
@@ -284,6 +284,7 @@ td.amount {
 }
 .newParticipantInput .participant {
 	display: table-cell;
+	width: 50%; /* make input field use more available width */
 }
 .participantInput .participationStatus,
 .newParticipantInput .participationStatus {


### PR DESCRIPTION
Fix https://github.com/xMartin/grouptabs/issues/73, please review @xMartin

Btw, the layout breaks at around 333px width (it did that before already). Should we add a min-width to the body so it can not break but will rather scroll? Or do we need to go even lower with the min-width?
