### PR TITLE
use same background color for desktop size to not make it look like a mobile app

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -15,7 +15,7 @@ body {
 	margin: 0;
 	color: #131313;
 	font-size: 18px;
-	background: #404045;
+	background: #f2f2f2;
 	font-family: SourceSansPro-Regular, sans-serif;
 }
 


### PR DESCRIPTION
Instead of the black bar style dark area, we can just use the normal app background. Then it looks less like a mobile app displayed on a desktop-size screen and more just nicely centered.