### PR TITLE
remove min-height to fix scrolling when not necessary

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -115,7 +115,6 @@ input[type=number] {
 	max-width: 500px;
 	min-width: 320px;
 	margin: 0 auto;
-	min-height: 100vh;
 }
 @media (min-width: 500px) and (min-height: 780px) {
 	#scenes {


### PR DESCRIPTION
As we talked about @xMartin. Currently the content always forces a scrollbar because of the min-height. It was only necessary when we had a different background color and is not needed anymore.