### PR TITLE
use valid SPDX license expression, fix warning during npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "http-server": "0.9.0",
     "jshint": "2.9.4"
   },
-  "license": "GPLv3"
+  "license": "GPL-3.0"
 }


### PR DESCRIPTION
Check it out @xMartin, there was a small warning during npm install