### PR TITLE
Optimize sync

### DIFF
--- a/js/app/db/manager.js
+++ b/js/app/db/manager.js
@@ -91,10 +91,10 @@ function (PouchDB, allDbs, createClass, iobject, Tab) {
     },
 
     connectTab: function (id) {
-      var db = this.initDb('tab/' + id);
+      var db = this.dbs[id] || this.initDb('tab/' + id);
 
       return (
-        db.connect()
+        db.connect({continuous: true})
         .then(function (docs) {
           return {
             createOrUpdate: this.transformDocs(id, docs),
@@ -102,6 +102,12 @@ function (PouchDB, allDbs, createClass, iobject, Tab) {
           };
         }.bind(this))
       );
+    },
+
+    disconnectTab: function (id) {
+      var db = this.dbs[id];
+
+      db.stopSyncingWhenSynced();
     },
 
     /**


### PR DESCRIPTION
Currently we have a lot of network traffic for syncing to the server (CouchDB) because we sync all tab databases in the app every few seconds to keep everything up to date.

In this branch we try to get a bit smarter and only sync the tab that we currently display (non if in tabs overview) or if a tab has unsynced changes in the app.