### PR TITLE
New header design

### DIFF
--- a/js/app/components/editentry.js
+++ b/js/app/components/editentry.js
@@ -108,7 +108,11 @@ function (React, createReactClass, PureRenderMixin, PropTypes, iobject, Form) {
       return (
         el('div', {className: 'scene editEntryScene'},
           el('div', {className: 'header'},
-            el('button', {className: 'left', onClick: this.props.handleCloseClick}, '×'),
+            el('button', {className: 'left', onClick: this.props.handleCloseClick},
+              el('svg', {height: 16, width: 16},
+                el('path', {d: 'm7.4983 0.5c0.8974 0 1.3404 1.0909 0.6973 1.7168l-4.7837 4.7832h11.573c1.3523-0.019125 1.3523 2.0191 0 2h-11.572l4.7832 4.7832c0.98163 0.94251-0.47155 2.3957-1.4141 1.4141l-6.4911-6.49c-0.387-0.3878-0.391-1.0228 0-1.414l6.4905-6.49c0.1883-0.1935 0.4468-0.30268 0.7168-0.3027z'})
+              )
+            ),
             el('h2', null, this.props.mode === 'new' ? 'New transaction' : 'Edit transaction'),
             el('button', {className: 'right create', onClick: this.handleSubmit}, 'Save')
           ),

--- a/js/app/components/list.js
+++ b/js/app/components/list.js
@@ -31,9 +31,9 @@ function (React, createReactClass, PureRenderMixin, PropTypes, TransactionList) 
       return (
         el('div', {className: 'scene listScene' + (this.props.visible ? '' : ' hidden')},
           el('div', {className: 'header'},
-            el('button', {onClick: this.props.handleChangeTabClick},
-              el('svg', {height: 15, width: 15, style: {opacity: 0.5}},
-                el('path', {d: 'm0 0v3h15v-3h-15zm0 6v3h15v-3h-15zm0 6v3h15v-3h-15z'})
+            el('button', {className: 'left', onClick: this.props.handleChangeTabClick},
+              el('svg', {height: 16, width: 16},
+                el('path', {d: 'm2 2c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12zm0 5c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12zm0 5c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12z'})
               )
             ),
             el('h2', null, this.props.tabName)

--- a/js/app/components/main.js
+++ b/js/app/components/main.js
@@ -32,9 +32,9 @@ function (React, createReactClass, PureRenderMixin, PropTypes, Loader, Overview)
       return (
         el('div', {className: 'scene mainScene' + (this.props.visible ? '' : ' hidden')},
           el('div', {className: 'header'},
-            el('button', {onClick: this.props.handleChangeTabClick},
-              el('svg', {height: 15, width: 15, style: {opacity: 0.5}},
-                el('path', {d: 'm0 0v3h15v-3h-15zm0 6v3h15v-3h-15zm0 6v3h15v-3h-15z'})
+            el('button', {className: 'left', onClick: this.props.handleChangeTabClick},
+              el('svg', {height: 16, width: 16},
+                el('path', {d: 'm2 2c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12zm0 5c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12zm0 5c-0.554 0-1 0.446-1 1s0.446 1 1 1h12c0.554 0 1-0.446 1-1s-0.446-1-1-1h-12z'})
               )
             ),
             el('h2', null, this.props.tabName)

--- a/styles/style.css
+++ b/styles/style.css
@@ -155,6 +155,10 @@ input[type=number] {
 	padding: 14px 0;
 	top: 0;
 	margin: 0;
+	max-width: 66%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .header #logo {
 	width: 44px;
@@ -318,6 +322,11 @@ td.amount {
 }
 .tabs button:first-child {
 	border-top-width: 1px;
+}
+
+.create-form input {
+	padding-right: 78px;
+	text-overflow: ellipsis;
 }
 
 .create-form button,

--- a/styles/style.css
+++ b/styles/style.css
@@ -65,6 +65,7 @@ button.selected {
 .header button.left {
 	background: transparent;
 	opacity: .5;
+	padding: 16px 10px
 }
 .header button.left:hover,
 .header button.left:focus {
@@ -142,29 +143,30 @@ input[type=number] {
 
 .header {
 	width: 100%;
-	height: 44px;
+	height: 56px;
 	margin-bottom: 1em;
 	position: relative;
 }
 .header h2 {
 	position: absolute;
-	top: 7px;
-	margin-left: 12px;
 	font-size: 22px;
+	left: 50%;
+	transform: translateX(-50%);
+	padding: 14px 0;
+	top: 0;
+	margin: 0;
 }
 .header #logo {
 	width: 44px;
+	position: absolute;
+	left: 50%;
+	transform: translateX(-200%);
+	border-radius: 50px;
+	padding: 6px;
 }
 
 .scene.hidden {
 	display: none;
-}
-
-.scene h2 {
-	margin-top: 0;
-	text-align: center;
-	display: inline-block;
-	font-weight: normal;
 }
 
 .empty-info,

--- a/styles/style.css
+++ b/styles/style.css
@@ -62,11 +62,13 @@ button.create {
 button.selected {
 	background: #bbb;
 }
-.editEntryScene .header button.left {
-	padding: 0;
-	color: #666;
-	font-size: 28px;
-	line-height: 100%;
+.header button.left {
+	background: transparent;
+	opacity: .5;
+}
+.header button.left:hover,
+.header button.left:focus {
+	opacity: 1;
 }
 
 .editEntryScene .header button.right {


### PR DESCRIPTION
Before :neutral_face: 
![screenshot from 2017-11-29 02-02-22](https://user-images.githubusercontent.com/925062/33352595-faf99400-d4a9-11e7-9774-a0e0f81049ff.png)

After :open_mouth: :heart_eyes:  More defined header, slightly larger to vertically center text with the floating button, centered text, better icons, removed background
![screenshot from 2017-11-29 02-01-01](https://user-images.githubusercontent.com/925062/33352596-fb1a10b8-d4a9-11e7-94d7-c851a5f24c12.png)
