### PR TITLE
Use smaller triangle for transactions toggle

### DIFF
--- a/js/app/components/main.js
+++ b/js/app/components/main.js
@@ -133,7 +133,7 @@ function (React, createReactClass, PureRenderMixin, PropTypes, SmoothScroll, Loa
                     className: 'transactions-heading transactions-heading-fixed',
                     onClick: this.onTransitionsTeaserClick
                   },
-                    '▼ Transactions'
+                    '▾ Transactions'
                   )
                   :
                   null


### PR DESCRIPTION
I thought I already used the small one, but didn’t. :)
Before & after:
![screenshot from 2018-03-14 22-31-01](https://user-images.githubusercontent.com/925062/37432133-a89ddb68-27d7-11e8-96f9-0db74d0ca173.png) ![screenshot from 2018-03-14 22-31-52](https://user-images.githubusercontent.com/925062/37432132-a8741f30-27d7-11e8-9c9a-d295c153cd12.png)
