### PR TITLE
Increase link color contrast to conform to WCAG AA

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -145,7 +145,7 @@ button.create {
 }
 
 .fake-link {
-	color: #bbb;
+	color: #666;
 	text-decoration: underline;
 	cursor: pointer;
 }


### PR DESCRIPTION
Before, color `#bbbbbb`
![Link color before bbb](https://user-images.githubusercontent.com/925062/59966852-3dd05180-9522-11e9-8586-c57fb127dc30.png)
Now with color `#666666`, the first one which conforms to WCAG AA: https://contrast-ratio.com/#%23666-on-%23f2f2f2
![Link color 666](https://user-images.githubusercontent.com/925062/59966853-3dd05180-9522-11e9-9fd4-cf3d685704c0.png)
