### PR TITLE
Initial replication timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-script:
-  - npm run test
-  - npm run build

--- a/src/db/manager.ts
+++ b/src/db/manager.ts
@@ -51,7 +51,7 @@ export default class DbManager {
   async connect() {
     const docsPerDb = await Promise.all(
       this.getAllDbs().map(async (db) => {
-        const docs = await db.db.connect();
+        const docs = await db.db.connect({ initialReplicationTimeout: 3200 });
         // @ts-ignore (apparently items in docs could be undefined)
         return this.docsToEntities(db.tabId, docs);
       })

--- a/src/db/tab.ts
+++ b/src/db/tab.ts
@@ -29,7 +29,7 @@ export default class {
   constructor(
     private readonly localDbName: string,
     private readonly remoteDbLocation: string,
-    private readonly changesHandler: ChangesHandler,
+    private readonly onChanges: ChangesHandler,
     adapter?: string
   ) {
     const myLog = log.extend(localDbName);
@@ -169,7 +169,7 @@ export default class {
         }
 
         this.logChanges("complete", info.results);
-        this.changesHandler(info.results);
+        this.onChanges(info.results);
       })
       .on("error", (error) => {
         throw new Error(error);


### PR DESCRIPTION
For situations with flaky connection this is supposed to make the app
show with outdated data rather than blocking with the spash screen
forever.

Regular syncing will update the data whenever possible.